### PR TITLE
Add Windows 11 inspired Pollinations chat workspace

### DIFF
--- a/.github/workflows/pages-build.yml
+++ b/.github/workflows/pages-build.yml
@@ -1,0 +1,57 @@
+name: Build and Deploy Unity Copilot Studio
+
+on:
+  push:
+    branches:
+      - work
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: unity-copilot-pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      POLLINATIONS_TOKEN: ${{ secrets.POLLINATIONS_TOKEN }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run validation suite
+        run: npm test
+
+      - name: Build static artifact
+        run: npm run build
+
+      - name: Upload artifact for GitHub Pages
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - id: deploy
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules/
+dist/
+.DS_Store
+

--- a/index.html
+++ b/index.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Unity Copilot Studio</title>
+    <meta
+      name="description"
+      content="A Windows 11 2025 inspired Pollinations AI chat workspace with model, voice, and theme controls."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Space+Grotesk:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/themes/prism-tomorrow.min.css" />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body class="theme-light">
+    <div class="wallpaper"></div>
+    <div class="desktop-shell">
+      <header class="taskbar" aria-label="Desktop status bar">
+        <div class="taskbar-left">
+          <span class="taskbar-logo" aria-hidden="true">◎</span>
+          <span class="taskbar-title">Unity Copilot Studio</span>
+        </div>
+        <div class="taskbar-right">
+          <span class="taskbar-indicator" id="connectionStatus" aria-live="polite">Idle</span>
+          <span class="taskbar-clock" id="taskbarClock">--:--</span>
+        </div>
+      </header>
+
+      <main class="window glass" role="main" aria-label="Unity Copilot Studio workspace">
+        <div class="window-header">
+          <div class="window-title">
+            <div class="title-icon" aria-hidden="true">🪟</div>
+            <div>
+              <h1>Unity Copilot Studio</h1>
+              <p>Windows 11 2025 experience for Pollinations conversations</p>
+            </div>
+          </div>
+          <div class="window-controls" aria-hidden="true">
+            <button type="button" class="window-button" title="Minimize"></button>
+            <button type="button" class="window-button" title="Maximize"></button>
+            <button type="button" class="window-button close" title="Close"></button>
+          </div>
+        </div>
+
+        <div class="window-body">
+          <aside class="control-pane" aria-label="Conversation controls">
+            <section class="panel">
+              <h2>Configuration</h2>
+              <label class="input-group">
+                <span>Text model</span>
+                <select id="modelSelect" aria-label="Pollinations text model"></select>
+              </label>
+              <label class="input-group">
+                <span>Voice</span>
+                <select id="voiceSelect" aria-label="Voice for text-to-speech"></select>
+              </label>
+              <label class="input-group">
+                <span>Theme</span>
+                <select id="themeSelect" aria-label="Interface theme">
+                  <option value="theme-light">Daylight</option>
+                  <option value="theme-dark">Aurora Dark</option>
+                  <option value="theme-amoled">Nightfall AMOLED</option>
+                </select>
+              </label>
+              <div class="input-group toggle">
+                <label for="memoryToggle">Memory sync</label>
+                <input type="checkbox" id="memoryToggle" checked aria-label="Allow assistant to store memories" />
+              </div>
+            </section>
+
+            <section class="panel">
+              <h2>Session snapshot</h2>
+              <dl class="session-meta">
+                <div>
+                  <dt>Model</dt>
+                  <dd id="modelBadge">&mdash;</dd>
+                </div>
+                <div>
+                  <dt>Voice</dt>
+                  <dd id="voiceBadge">&mdash;</dd>
+                </div>
+                <div>
+                  <dt>Theme</dt>
+                  <dd id="themeBadge">Daylight</dd>
+                </div>
+              </dl>
+            </section>
+
+            <section class="panel memories-panel">
+              <div class="panel-header">
+                <h2>Saved memories</h2>
+                <button type="button" id="clearMemories" class="ghost-button">Clear</button>
+              </div>
+              <p class="panel-help">
+                Memories guide future replies. The latest entries are automatically attached to requests.
+              </p>
+              <ol id="memoryList" class="memory-list" aria-live="polite"></ol>
+            </section>
+          </aside>
+
+          <section class="chat-pane" aria-label="Conversation thread">
+            <div class="chat-log" id="chatLog" role="log" aria-live="polite"></div>
+            <form id="composer" class="composer" autocomplete="off">
+              <label for="messageInput" class="sr-only">Message</label>
+              <textarea
+                id="messageInput"
+                rows="1"
+                placeholder="Type a message to Pollinations..."
+                aria-label="Message input"
+                required
+              ></textarea>
+              <div class="composer-footer">
+                <span id="charCounter">0 characters</span>
+                <div class="composer-actions">
+                  <button type="button" class="ghost-button" id="resetChat">Reset</button>
+                  <button type="submit" id="sendButton" class="primary-button">Send</button>
+                </div>
+              </div>
+            </form>
+          </section>
+        </div>
+      </main>
+    </div>
+
+    <div class="toast" id="toast" role="status" aria-live="polite" hidden></div>
+
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js" integrity="sha384-i2RImOSGgPizxgxYkWwaP42gnikIze8ih/7gToYtL6vhfVqlhK/SXGEdq8np5xpo" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js" integrity="sha384-JCJhkm1b4GPRW6K5YnlNdd+y9QNFuIBqmoeZaZX6mE6xPD58Ll35H5TADaBrZEcD" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-core.min.js" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/plugins/autoloader/prism-autoloader.min.js" crossorigin="anonymous"></script>
+    <script src="script.js" defer></script>
+  </body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1260 @@
+{
+  "name": "unity-copilot-studio",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "unity-copilot-studio",
+      "version": "1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/corser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
+      "integrity": "sha512-utCYNzRSQIZNPIcGZdQc92UVJYAhtGAteCFg0yRaFm8f0P+CPtyGyHXJcGXnffjCybUCEx3FQ2G7U3/o9eIkVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/http-proxy": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/http-server": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/http-server/-/http-server-14.1.1.tgz",
+      "integrity": "sha512-+cbxadF40UXd9T01zUHgA+rlo2Bg1Srer4+B4NwIHdaGxAGGv59nYRnGGDJ9LBk7alpS0US+J+bLLdQOOkJq4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-auth": "^2.0.1",
+        "chalk": "^4.1.2",
+        "corser": "^2.0.1",
+        "he": "^1.2.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy": "^1.18.1",
+        "mime": "^1.6.0",
+        "minimist": "^1.2.6",
+        "opener": "^1.5.1",
+        "portfinder": "^1.0.28",
+        "secure-compare": "3.0.1",
+        "union": "~0.5.0",
+        "url-join": "^4.0.1"
+      },
+      "bin": {
+        "http-server": "bin/http-server"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "24.1.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.1.3.tgz",
+      "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.0.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.4",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.22",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.22.tgz",
+      "integrity": "sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true,
+      "license": "(WTFPL OR MIT)",
+      "bin": {
+        "opener": "bin/opener-bin.js"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/portfinder": {
+      "version": "1.0.37",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.37.tgz",
+      "integrity": "sha512-yuGIEjDAYnnOex9ddMnKZEMFE0CcGo6zbfzDklkmT1m5z734ss6JMzN9rNB3+RR7iS+F10D4/BVIaXOyh8PQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async": "^3.2.6",
+        "debug": "^4.3.6"
+      },
+      "engines": {
+        "node": ">= 10.12"
+      }
+    },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/secure-compare": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
+      "integrity": "sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/union": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/union/-/union-0.5.0.tgz",
+      "integrity": "sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==",
+      "dev": true,
+      "dependencies": {
+        "qs": "^6.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "unity-copilot-studio",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Static Windows 11 style Pollinations chat workspace for GitHub Pages.",
+  "scripts": {
+    "test": "node scripts/validate.js",
+    "build": "node scripts/build.js"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/script.js
+++ b/script.js
@@ -1,0 +1,672 @@
+/* global marked, DOMPurify, Prism */
+'use strict';
+
+const STORAGE_KEYS = {
+  theme: 'unity-theme',
+  memories: 'unity-memories',
+  history: 'unity-history',
+  preferences: 'unity-preferences'
+};
+
+const FALLBACK_MODELS = [
+  { id: 'openai', label: 'OpenAI (GPT-4o mini)' },
+  { id: 'mistral', label: 'Mistral' },
+  { id: 'llama', label: 'LLaMA Fusion' },
+  { id: 'deepseek', label: 'DeepSeek' },
+  { id: 'claude-hybridspace', label: 'Claude HybridSpace' }
+];
+
+const FALLBACK_VOICES = ['alloy', 'echo', 'fable', 'onyx', 'nova', 'shimmer'];
+
+const API_ENDPOINT = 'https://text.pollinations.ai/openai?referrer=unity-copilot-studio.app';
+const MODELS_ENDPOINT = 'https://text.pollinations.ai/models?referrer=unity-copilot-studio.app';
+
+const state = {
+  aiInstruct: '',
+  history: [],
+  memories: [],
+  selectedModel: FALLBACK_MODELS[0].id,
+  selectedVoice: FALLBACK_VOICES[0],
+  selectedTheme: 'theme-light',
+  memoryEnabled: true,
+  isSending: false,
+  availableModels: FALLBACK_MODELS,
+  availableVoices: [...FALLBACK_VOICES]
+};
+
+const elements = {};
+
+const formatters = {
+  markdown(input) {
+    if (!input) {
+      return '';
+    }
+    const rawHtml = marked.parse(input, { mangle: false, headerIds: false });
+    return DOMPurify.sanitize(rawHtml, { USE_PROFILES: { html: true } });
+  }
+};
+
+function bindElements() {
+  elements.modelSelect = document.getElementById('modelSelect');
+  elements.voiceSelect = document.getElementById('voiceSelect');
+  elements.themeSelect = document.getElementById('themeSelect');
+  elements.memoryToggle = document.getElementById('memoryToggle');
+  elements.memoryList = document.getElementById('memoryList');
+  elements.clearMemories = document.getElementById('clearMemories');
+  elements.chatLog = document.getElementById('chatLog');
+  elements.composer = document.getElementById('composer');
+  elements.messageInput = document.getElementById('messageInput');
+  elements.sendButton = document.getElementById('sendButton');
+  elements.resetChat = document.getElementById('resetChat');
+  elements.charCounter = document.getElementById('charCounter');
+  elements.connectionStatus = document.getElementById('connectionStatus');
+  elements.toast = document.getElementById('toast');
+  elements.modelBadge = document.getElementById('modelBadge');
+  elements.voiceBadge = document.getElementById('voiceBadge');
+  elements.themeBadge = document.getElementById('themeBadge');
+}
+
+function configureLibraries() {
+  if (window.marked) {
+    marked.setOptions({
+      breaks: true,
+      gfm: true,
+      mangle: false,
+      headerIds: false
+    });
+  }
+  if (Prism?.plugins?.autoloader) {
+    Prism.plugins.autoloader.languages_path =
+      'https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/';
+  }
+}
+
+function initClock() {
+  const clock = document.getElementById('taskbarClock');
+  if (!clock) return;
+
+  const updateClock = () => {
+    const now = new Date();
+    clock.textContent = now.toLocaleTimeString([], {
+      hour: '2-digit',
+      minute: '2-digit'
+    });
+  };
+
+  updateClock();
+  setInterval(updateClock, 30_000);
+}
+
+function loadStoredState() {
+  try {
+    const storedTheme = localStorage.getItem(STORAGE_KEYS.theme);
+    if (storedTheme) {
+      state.selectedTheme = storedTheme;
+    }
+
+    const storedMemories = localStorage.getItem(STORAGE_KEYS.memories);
+    if (storedMemories) {
+      const parsed = JSON.parse(storedMemories);
+      if (Array.isArray(parsed)) {
+        state.memories = parsed;
+      }
+    }
+
+    const storedHistory = localStorage.getItem(STORAGE_KEYS.history);
+    if (storedHistory) {
+      const parsed = JSON.parse(storedHistory);
+      if (Array.isArray(parsed)) {
+        state.history = parsed;
+      }
+    }
+
+    const preferences = localStorage.getItem(STORAGE_KEYS.preferences);
+    if (preferences) {
+      const parsed = JSON.parse(preferences);
+      if (parsed && typeof parsed === 'object') {
+        state.selectedModel = parsed.model || state.selectedModel;
+        state.selectedVoice = parsed.voice || state.selectedVoice;
+        state.memoryEnabled = parsed.memoryEnabled ?? state.memoryEnabled;
+      }
+    }
+  } catch (error) {
+    console.warn('Unable to load stored state', error);
+  }
+}
+
+function persistState() {
+  try {
+    localStorage.setItem(STORAGE_KEYS.theme, state.selectedTheme);
+    localStorage.setItem(STORAGE_KEYS.memories, JSON.stringify(state.memories));
+    localStorage.setItem(STORAGE_KEYS.history, JSON.stringify(state.history));
+    localStorage.setItem(
+      STORAGE_KEYS.preferences,
+      JSON.stringify({
+        model: state.selectedModel,
+        voice: state.selectedVoice,
+        memoryEnabled: state.memoryEnabled
+      })
+    );
+  } catch (error) {
+    console.warn('Unable to persist state', error);
+  }
+}
+
+function applyTheme(themeClass) {
+  const themes = ['theme-light', 'theme-dark', 'theme-amoled'];
+  themes.forEach((cls) => document.body.classList.remove(cls));
+  document.body.classList.add(themeClass);
+  state.selectedTheme = themeClass;
+  elements.themeBadge.textContent =
+    themeClass === 'theme-dark' ? 'Aurora Dark' : themeClass === 'theme-amoled' ? 'Nightfall AMOLED' : 'Daylight';
+  persistState();
+}
+
+function populateSelect(select, options, selectedValue) {
+  if (!select) return;
+  select.innerHTML = '';
+  options.forEach((opt) => {
+    const option = document.createElement('option');
+    if (typeof opt === 'string') {
+      option.value = opt;
+      option.textContent = opt;
+    } else {
+      option.value = opt.id;
+      option.textContent = opt.label || opt.id;
+    }
+    if (option.value === selectedValue) {
+      option.selected = true;
+    }
+    select.appendChild(option);
+  });
+}
+
+async function fetchModels() {
+  let data;
+  try {
+    const response = await fetch(MODELS_ENDPOINT, { cache: 'no-store' });
+    if (response.ok) {
+      data = await response.json();
+    } else {
+      throw new Error(`Status ${response.status}`);
+    }
+  } catch (error) {
+    console.warn('Falling back to predefined models', error);
+    return {
+      models: FALLBACK_MODELS,
+      voices: FALLBACK_VOICES
+    };
+  }
+
+  const models = [];
+  const voices = new Set(FALLBACK_VOICES);
+
+  const processModel = (id, details) => {
+    if (!id) return;
+    const label = details?.title || details?.name || details?.label || id;
+    models.push({ id, label });
+    if (details?.voices && Array.isArray(details.voices)) {
+      details.voices.forEach((voice) => {
+        if (voice && typeof voice === 'string') {
+          voices.add(voice);
+        } else if (voice?.id) {
+          voices.add(voice.id);
+        }
+      });
+    }
+  };
+
+  if (Array.isArray(data)) {
+    data.forEach((item) => {
+      if (typeof item === 'string') {
+        models.push({ id: item, label: item });
+      } else if (item && typeof item === 'object') {
+        processModel(item.id || item.name, item);
+      }
+    });
+  } else if (data && typeof data === 'object') {
+    Object.entries(data).forEach(([id, details]) => processModel(id, details));
+  }
+
+  const uniqueModels = models.length ? models : FALLBACK_MODELS;
+  return {
+    models: uniqueModels,
+    voices: Array.from(voices)
+  };
+}
+
+function updateSessionSnapshot() {
+  const selectedModelOption = state.availableModels.find((m) => m.id === state.selectedModel);
+  elements.modelBadge.textContent = selectedModelOption ? selectedModelOption.label : state.selectedModel;
+  elements.voiceBadge.textContent = state.selectedVoice;
+}
+
+function renderMemories() {
+  elements.memoryList.innerHTML = '';
+  if (!state.memories.length) {
+    const placeholder = document.createElement('li');
+    placeholder.textContent = 'No saved memories yet.';
+    placeholder.classList.add('empty');
+    elements.memoryList.appendChild(placeholder);
+    return;
+  }
+
+  state.memories.slice(-10).forEach((memory) => {
+    const item = document.createElement('li');
+    item.textContent = memory;
+    elements.memoryList.appendChild(item);
+  });
+}
+
+function setConnectionStatus(text, variant = 'idle') {
+  if (!elements.connectionStatus) return;
+  elements.connectionStatus.textContent = text;
+  elements.connectionStatus.dataset.status = variant;
+}
+
+function trimHistory() {
+  const limit = 60;
+  if (state.history.length > limit) {
+    state.history = state.history.slice(-limit);
+  }
+}
+
+function trimMemories() {
+  const limit = 50;
+  if (state.memories.length > limit) {
+    state.memories = state.memories.slice(-limit);
+  }
+}
+
+function showToast(message, variant = 'info', duration = 3200) {
+  if (!elements.toast) return;
+  elements.toast.textContent = message;
+  elements.toast.classList.remove('success', 'error');
+  if (variant === 'success') {
+    elements.toast.classList.add('success');
+  } else if (variant === 'error') {
+    elements.toast.classList.add('error');
+  }
+  elements.toast.hidden = false;
+  window.setTimeout(() => {
+    elements.toast.hidden = true;
+  }, duration);
+}
+
+function createAvatar(role) {
+  const avatar = document.createElement('div');
+  avatar.className = 'chat-avatar';
+  avatar.textContent = role === 'assistant' ? '🤖' : '🧑🏻';
+  return avatar;
+}
+
+function formatTimestamp(timestamp) {
+  if (!timestamp) return '';
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return '';
+  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
+
+function parseStructuredContent(content) {
+  const workingContent = { text: content || '', codeBlocks: [], images: [], memories: [] };
+  if (!content) {
+    return workingContent;
+  }
+
+  const memoryPattern = /\[memory\]([\s\S]*?)\[\/memory\]/gi;
+  workingContent.text = workingContent.text.replace(memoryPattern, (_, memoryBody) => {
+    if (memoryBody) {
+      workingContent.memories.push(memoryBody.trim());
+    }
+    return '';
+  });
+
+  const imagePattern = /\[IMAGE\]([\s\S]*?)\[\/IMAGE\]/gi;
+  workingContent.text = workingContent.text.replace(imagePattern, (_, url) => {
+    if (url) {
+      workingContent.images.push(url.trim());
+    }
+    return '';
+  });
+
+  const codePattern = /\[CODE\]([\s\S]*?)\[\/CODE\]/gi;
+  workingContent.text = workingContent.text.replace(codePattern, (_, codeBody) => {
+    if (!codeBody) return '';
+    const tripleMatch = codeBody.match(/```(\w+)?\n([\s\S]*?)```/);
+    if (tripleMatch) {
+      const [, language = '', rawCode = ''] = tripleMatch;
+      workingContent.codeBlocks.push({
+        language: language.trim().toLowerCase(),
+        code: rawCode.trim()
+      });
+    } else {
+      workingContent.codeBlocks.push({ language: '', code: codeBody.trim() });
+    }
+    return '';
+  });
+
+  workingContent.text = workingContent.text.trim();
+  return workingContent;
+}
+
+function appendChatMessage(message) {
+  if (!elements.chatLog) return;
+  const row = document.createElement('div');
+  row.className = `chat-message ${message.role}`;
+
+  const avatar = createAvatar(message.role);
+  const bubble = document.createElement('div');
+  bubble.className = 'chat-bubble';
+
+  const content = parseStructuredContent(message.content);
+
+  if (content.text) {
+    const textWrapper = document.createElement('div');
+    textWrapper.className = 'chat-text';
+    textWrapper.innerHTML = formatters.markdown(content.text);
+    bubble.appendChild(textWrapper);
+  }
+
+  content.images.forEach((url) => {
+    if (!/^https?:\/\//i.test(url)) return;
+    const image = document.createElement('img');
+    image.src = url;
+    image.alt = 'AI generated illustration';
+    bubble.appendChild(image);
+  });
+
+  content.codeBlocks.forEach(({ language, code }) => {
+    const pre = document.createElement('pre');
+    const codeEl = document.createElement('code');
+    if (language) {
+      codeEl.className = `language-${language}`;
+    }
+    codeEl.textContent = code;
+    pre.appendChild(codeEl);
+    bubble.appendChild(pre);
+    Prism.highlightElement(codeEl);
+  });
+
+  if (content.memories.length) {
+    const memoryWrapper = document.createElement('div');
+    memoryWrapper.className = 'chat-meta';
+    memoryWrapper.textContent = `Stored memories: ${content.memories.join(' | ')}`;
+    bubble.appendChild(memoryWrapper);
+  }
+
+  const meta = document.createElement('div');
+  meta.className = 'chat-meta';
+  meta.textContent = formatTimestamp(message.timestamp);
+  bubble.appendChild(meta);
+
+  if (message.role === 'assistant') {
+    row.appendChild(avatar);
+    row.appendChild(bubble);
+  } else {
+    row.appendChild(bubble);
+    row.appendChild(avatar);
+  }
+
+  elements.chatLog.appendChild(row);
+  elements.chatLog.scrollTop = elements.chatLog.scrollHeight;
+}
+
+function renderChat() {
+  if (!elements.chatLog) return;
+  elements.chatLog.innerHTML = '';
+  state.history.forEach((message) => appendChatMessage(message));
+}
+
+function addSystemWelcomeIfNeeded() {
+  if (state.history.length) return;
+  const welcome = {
+    role: 'assistant',
+    timestamp: new Date().toISOString(),
+    content:
+      'Welcome to your Windows 11 2025 inspired workspace! I am ready to chat, craft code snippets, and fetch Pollinations images. ' +
+      'Adjust the model, voice, and theme from the control hub, then send me a message to begin.'
+  };
+  state.history.push(welcome);
+}
+
+function updateCharCounter() {
+  if (!elements.charCounter || !elements.messageInput) return;
+  const length = elements.messageInput.value.trim().length;
+  elements.charCounter.textContent = `${length} character${length === 1 ? '' : 's'}`;
+}
+
+function autoResizeTextarea() {
+  if (!elements.messageInput) return;
+  elements.messageInput.style.height = 'auto';
+  elements.messageInput.style.height = `${elements.messageInput.scrollHeight}px`;
+}
+
+function handleThemeChange(event) {
+  applyTheme(event.target.value);
+}
+
+function handleModelChange(event) {
+  state.selectedModel = event.target.value;
+  updateSessionSnapshot();
+  persistState();
+}
+
+function handleVoiceChange(event) {
+  state.selectedVoice = event.target.value;
+  updateSessionSnapshot();
+  persistState();
+}
+
+function handleMemoryToggle(event) {
+  state.memoryEnabled = Boolean(event.target.checked);
+  persistState();
+  showToast(state.memoryEnabled ? 'Memories will be recorded.' : 'Memory sync paused.', 'info');
+}
+
+function clearMemories() {
+  state.memories = [];
+  renderMemories();
+  persistState();
+  showToast('All memories cleared.', 'info');
+}
+
+function resetChat() {
+  state.history = [];
+  addSystemWelcomeIfNeeded();
+  renderChat();
+  persistState();
+  showToast('Conversation reset.', 'info');
+}
+
+function buildSystemPrompt() {
+  const themeLabel = elements.themeSelect?.selectedOptions?.[0]?.textContent || 'Daylight';
+  const memoryBlock = state.memories.slice(-10).map((memory) => `[memory]${memory}[/memory]`).join('\n');
+  const memoryCopy = state.memories.slice(-10).map((memory, index) => `${index + 1}. ${memory}`).join('\n');
+
+  return [
+    state.aiInstruct,
+    '---',
+    'Session parameters:',
+    `- Active theme: ${themeLabel}`,
+    `- Preferred voice: ${state.selectedVoice}`,
+    `- Selected model: ${state.selectedModel}`,
+    state.memoryEnabled && memoryBlock
+      ? `Memories provided by the workspace (with plain copies):\n${memoryBlock}\nPlain list:\n${memoryCopy}`
+      : 'No memories are currently shared for this session.',
+    'Always include any generated code between [CODE] markers with fenced language blocks, image URLs between [IMAGE] markers, ' +
+      'and new long-term memories between [memory] markers as described.'
+  ]
+    .filter(Boolean)
+    .join('\n');
+}
+
+function buildPayload() {
+  const historySlice = state.history.slice(-10).map(({ role, content }) => ({ role, content }));
+  return {
+    model: state.selectedModel,
+    voice: state.selectedVoice,
+    private: true,
+    messages: [{ role: 'system', content: buildSystemPrompt() }, ...historySlice]
+  };
+}
+
+async function sendMessage(event) {
+  event.preventDefault();
+  if (state.isSending) return;
+
+  const userInput = elements.messageInput.value.trim();
+  if (!userInput) return;
+
+  const userMessage = {
+    role: 'user',
+    content: userInput,
+    timestamp: new Date().toISOString()
+  };
+
+  state.history.push(userMessage);
+  trimHistory();
+  appendChatMessage(userMessage);
+  persistState();
+
+  elements.messageInput.value = '';
+  updateCharCounter();
+  autoResizeTextarea();
+
+  state.isSending = true;
+  elements.sendButton.disabled = true;
+  setConnectionStatus('Contacting Pollinations…', 'busy');
+
+  try {
+    const payload = buildPayload();
+    const response = await fetch(API_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(payload)
+    });
+
+    if (!response.ok) {
+      throw new Error(`Request failed: ${response.status}`);
+    }
+
+    const data = await response.json();
+    const assistantContent =
+      data?.choices?.[0]?.message?.content || data?.message || 'The assistant returned an empty response.';
+
+    const assistantMessage = {
+      role: 'assistant',
+      content: assistantContent,
+      timestamp: new Date().toISOString()
+    };
+
+    state.history.push(assistantMessage);
+    trimHistory();
+    appendChatMessage(assistantMessage);
+
+    const parsed = parseStructuredContent(assistantContent);
+    if (state.memoryEnabled && parsed.memories.length) {
+      parsed.memories.forEach((memory) => {
+        if (!state.memories.includes(memory)) {
+          state.memories.push(memory);
+        }
+      });
+      trimMemories();
+      renderMemories();
+    }
+
+    persistState();
+    showToast('Assistant replied.', 'success');
+    setConnectionStatus('Idle', 'idle');
+  } catch (error) {
+    console.error(error);
+    showToast('Unable to reach Pollinations. Please try again.', 'error');
+    setConnectionStatus('Error', 'error');
+
+    const errorMessage = {
+      role: 'assistant',
+      content: 'I could not reach the Pollinations API just now. Please retry in a moment.',
+      timestamp: new Date().toISOString()
+    };
+
+    state.history.push(errorMessage);
+    trimHistory();
+    appendChatMessage(errorMessage);
+    persistState();
+  } finally {
+    state.isSending = false;
+    elements.sendButton.disabled = false;
+  }
+}
+
+function handleKeyboardSubmit(event) {
+  if (event.key === 'Enter' && !event.shiftKey) {
+    event.preventDefault();
+    elements.composer.requestSubmit();
+  }
+}
+
+async function initialize() {
+  bindElements();
+  configureLibraries();
+  initClock();
+  loadStoredState();
+  applyTheme(state.selectedTheme);
+
+  const preferencesLoaded = state.memoryEnabled;
+  elements.memoryToggle.checked = preferencesLoaded;
+
+  try {
+    const response = await fetch('ai-instruct.txt', { cache: 'no-store' });
+    if (response.ok) {
+      state.aiInstruct = (await response.text()).trim();
+    } else {
+      throw new Error(`Failed to fetch ai-instruct.txt: ${response.status}`);
+    }
+  } catch (error) {
+    console.error(error);
+    state.aiInstruct = 'You are a helpful assistant.';
+    showToast('Could not load ai-instruct.txt, using a fallback prompt.', 'error');
+  }
+
+  const { models, voices } = await fetchModels();
+  state.availableModels = models;
+  state.availableVoices = voices;
+
+  if (!state.availableModels.find((model) => model.id === state.selectedModel)) {
+    state.selectedModel = state.availableModels[0]?.id || state.selectedModel;
+  }
+
+  if (!state.availableVoices.includes(state.selectedVoice)) {
+    state.selectedVoice = state.availableVoices[0] || state.selectedVoice;
+  }
+
+  populateSelect(elements.modelSelect, models, state.selectedModel);
+  populateSelect(elements.voiceSelect, voices, state.selectedVoice);
+  elements.themeSelect.value = state.selectedTheme;
+
+  elements.memoryToggle.checked = state.memoryEnabled;
+
+  addSystemWelcomeIfNeeded();
+  renderChat();
+  renderMemories();
+  updateSessionSnapshot();
+  updateCharCounter();
+  autoResizeTextarea();
+  setConnectionStatus('Idle', 'idle');
+
+  elements.modelSelect.addEventListener('change', handleModelChange);
+  elements.voiceSelect.addEventListener('change', handleVoiceChange);
+  elements.themeSelect.addEventListener('change', handleThemeChange);
+  elements.memoryToggle.addEventListener('change', handleMemoryToggle);
+  elements.clearMemories.addEventListener('click', clearMemories);
+  elements.resetChat.addEventListener('click', resetChat);
+  elements.messageInput.addEventListener('input', () => {
+    updateCharCounter();
+    autoResizeTextarea();
+  });
+  elements.messageInput.addEventListener('keydown', handleKeyboardSubmit);
+  elements.composer.addEventListener('submit', sendMessage);
+}
+
+document.addEventListener('DOMContentLoaded', initialize);

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const DIST = path.join(ROOT, 'dist');
+
+function ensureDir(dir) {
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+function copyFile(from, to) {
+  ensureDir(path.dirname(to));
+  fs.copyFileSync(from, to);
+}
+
+function copyDirectory(from, to) {
+  if (!fs.existsSync(from)) return;
+  ensureDir(to);
+  for (const entry of fs.readdirSync(from, { withFileTypes: true })) {
+    const source = path.join(from, entry.name);
+    const destination = path.join(to, entry.name);
+    if (entry.isDirectory()) {
+      copyDirectory(source, destination);
+    } else if (entry.isFile()) {
+      copyFile(source, destination);
+    }
+  }
+}
+
+function main() {
+  fs.rmSync(DIST, { recursive: true, force: true });
+  ensureDir(DIST);
+
+  const files = ['index.html', 'styles.css', 'script.js', 'ai-instruct.txt'];
+  files.forEach((file) => {
+    copyFile(path.join(ROOT, file), path.join(DIST, file));
+  });
+
+  copyDirectory(path.join(ROOT, 'assets'), path.join(DIST, 'assets'));
+
+  console.log('Build output prepared at', DIST);
+}
+
+main();

--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function readText(filePath) {
+  return fs.readFileSync(filePath, 'utf8');
+}
+
+function main() {
+  const runningInCI = process.env.GITHUB_ACTIONS === 'true';
+  if (runningInCI) {
+    assert(process.env.POLLINATIONS_TOKEN, 'POLLINATIONS_TOKEN secret must be provided in CI builds.');
+  }
+
+  const requiredFiles = ['index.html', 'styles.css', 'script.js', 'ai-instruct.txt'];
+  requiredFiles.forEach((file) => {
+    const resolved = path.join(ROOT, file);
+    assert(fs.existsSync(resolved), `Missing required file: ${file}`);
+  });
+
+  const html = readText(path.join(ROOT, 'index.html'));
+  ['modelSelect', 'voiceSelect', 'themeSelect', 'chatLog', 'composer', 'memoryList'].forEach((id) => {
+    assert(html.includes(`id="${id}"`), `Expected element with id="${id}" in index.html`);
+  });
+  assert(html.includes('Windows 11 2025 experience'), 'index.html should describe the Windows 11 2025 style experience.');
+
+  const js = readText(path.join(ROOT, 'script.js'));
+  ['API_ENDPOINT', 'buildSystemPrompt', 'parseStructuredContent', 'fetchModels'].forEach((token) => {
+    assert(js.includes(token), `script.js must include ${token}.`);
+  });
+
+  const css = readText(path.join(ROOT, 'styles.css'));
+  ['.taskbar', '.window', '.chat-bubble', '.memory-list'].forEach((selector) => {
+    assert(css.includes(selector), `styles.css missing expected selector ${selector}`);
+  });
+
+  console.log('Validation checks passed.');
+}
+
+main();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,680 @@
+:root {
+  color-scheme: light;
+  --font-sans: "Inter", "Segoe UI", sans-serif;
+  --font-display: "Space Grotesk", "Segoe UI", sans-serif;
+  --surface-glass: rgba(255, 255, 255, 0.65);
+  --surface-panel: rgba(255, 255, 255, 0.55);
+  --surface-panel-strong: rgba(255, 255, 255, 0.75);
+  --surface-chat-user: linear-gradient(135deg, rgba(116, 153, 255, 0.85), rgba(75, 115, 255, 0.85));
+  --surface-chat-assistant: rgba(255, 255, 255, 0.8);
+  --stroke: rgba(255, 255, 255, 0.35);
+  --text-strong: #11131f;
+  --text-muted: rgba(17, 19, 31, 0.65);
+  --text-inverse: #ffffff;
+  --accent: #5274ff;
+  --accent-soft: rgba(82, 116, 255, 0.2);
+  --shadow-soft: 0 20px 60px rgba(50, 60, 90, 0.25);
+  --radius-large: 28px;
+  --radius-medium: 18px;
+  --radius-small: 12px;
+  --blur-heavy: blur(36px);
+  --blur-medium: blur(18px);
+}
+
+body.theme-dark {
+  color-scheme: dark;
+  --surface-glass: rgba(32, 36, 62, 0.72);
+  --surface-panel: rgba(30, 34, 58, 0.78);
+  --surface-panel-strong: rgba(42, 46, 76, 0.85);
+  --surface-chat-assistant: rgba(38, 43, 71, 0.82);
+  --surface-chat-user: linear-gradient(135deg, rgba(169, 112, 255, 0.85), rgba(95, 178, 255, 0.9));
+  --stroke: rgba(102, 112, 169, 0.35);
+  --text-strong: #f3f5ff;
+  --text-muted: rgba(224, 229, 255, 0.6);
+  --accent: #8ea6ff;
+  --accent-soft: rgba(142, 166, 255, 0.25);
+  --shadow-soft: 0 30px 70px rgba(8, 12, 34, 0.55);
+}
+
+body.theme-amoled {
+  color-scheme: dark;
+  --surface-glass: rgba(8, 10, 18, 0.78);
+  --surface-panel: rgba(12, 14, 24, 0.92);
+  --surface-panel-strong: rgba(18, 22, 32, 0.95);
+  --surface-chat-assistant: rgba(22, 26, 40, 0.92);
+  --surface-chat-user: linear-gradient(135deg, rgba(255, 106, 189, 0.8), rgba(126, 172, 255, 0.9));
+  --stroke: rgba(80, 96, 180, 0.28);
+  --text-strong: #f8fbff;
+  --text-muted: rgba(248, 251, 255, 0.56);
+  --accent: #9ab6ff;
+  --accent-soft: rgba(154, 182, 255, 0.22);
+  --shadow-soft: 0 24px 84px rgba(0, 0, 0, 0.65);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: var(--font-sans);
+  color: var(--text-strong);
+  background: radial-gradient(circle at 20% 20%, rgba(164, 205, 255, 0.5), transparent 60%),
+    radial-gradient(circle at 80% 0%, rgba(255, 155, 222, 0.4), transparent 55%),
+    radial-gradient(circle at 50% 80%, rgba(126, 169, 255, 0.45), transparent 65%), #e6ecff;
+  overflow: hidden;
+}
+
+.wallpaper {
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(circle at 25% 20%, rgba(255, 255, 255, 0.35), transparent 60%),
+    radial-gradient(circle at 75% 10%, rgba(82, 116, 255, 0.25), transparent 55%),
+    radial-gradient(circle at 85% 85%, rgba(255, 135, 221, 0.25), transparent 60%);
+  filter: var(--blur-medium);
+  z-index: 0;
+  pointer-events: none;
+}
+
+.desktop-shell {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  padding: 32px clamp(24px, 5vw, 80px) 40px;
+}
+
+.taskbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 20px;
+  margin-bottom: 24px;
+  border-radius: var(--radius-large);
+  background: var(--surface-glass);
+  border: 1px solid var(--stroke);
+  backdrop-filter: var(--blur-heavy);
+  box-shadow: var(--shadow-soft);
+}
+
+.taskbar-left {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 600;
+  font-family: var(--font-display);
+}
+
+.taskbar-logo {
+  font-size: 1.4rem;
+  display: grid;
+  place-items: center;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.taskbar-right {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 0.95rem;
+  color: var(--text-muted);
+}
+
+.taskbar-indicator[data-status='busy'] {
+  color: #ffb648;
+}
+
+.taskbar-indicator[data-status='error'] {
+  color: #ff6b9a;
+}
+
+.taskbar-indicator[data-status='idle'] {
+  color: var(--text-muted);
+}
+
+.taskbar-clock {
+  font-variant-numeric: tabular-nums;
+}
+
+.window {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  border-radius: var(--radius-large);
+  background: var(--surface-glass);
+  border: 1px solid var(--stroke);
+  backdrop-filter: var(--blur-heavy);
+  box-shadow: var(--shadow-soft);
+  overflow: hidden;
+  min-height: 0;
+}
+
+.window-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 24px clamp(24px, 5vw, 48px) 18px;
+  border-bottom: 1px solid var(--stroke);
+}
+
+.window-title {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+}
+
+.window-title h1 {
+  margin: 0;
+  font-size: clamp(1.3rem, 1.8vw, 1.6rem);
+  font-weight: 600;
+}
+
+.window-title p {
+  margin: 4px 0 0;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.title-icon {
+  width: 46px;
+  height: 46px;
+  border-radius: 16px;
+  display: grid;
+  place-items: center;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-size: 1.4rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+}
+
+.window-controls {
+  display: flex;
+  gap: 12px;
+}
+
+.window-button {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(255, 255, 255, 0.7);
+  box-shadow: inset 0 1px 1px rgba(255, 255, 255, 0.6), 0 1px 4px rgba(20, 24, 40, 0.2);
+  cursor: pointer;
+}
+
+.window-button.close {
+  background: rgba(255, 113, 113, 0.85);
+}
+
+.window-body {
+  display: grid;
+  grid-template-columns: minmax(260px, 320px) 1fr;
+  gap: clamp(20px, 3vw, 36px);
+  padding: 24px clamp(24px, 5vw, 48px) 40px;
+  min-height: 0;
+}
+
+.control-pane {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  min-height: 0;
+}
+
+.panel {
+  background: var(--surface-panel);
+  border-radius: var(--radius-medium);
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  padding: 20px 22px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), 0 14px 34px rgba(35, 42, 78, 0.12);
+  backdrop-filter: var(--blur-medium);
+}
+
+.panel h2 {
+  margin: 0 0 14px;
+  font-family: var(--font-display);
+  font-size: 1.05rem;
+}
+
+.input-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 16px;
+  font-size: 0.95rem;
+}
+
+.input-group span,
+.input-group label {
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.input-group select,
+.input-group input[type="checkbox"],
+textarea,
+button {
+  font: inherit;
+}
+
+.input-group select {
+  appearance: none;
+  border-radius: var(--radius-small);
+  border: 1px solid rgba(255, 255, 255, 0.55);
+  background: rgba(255, 255, 255, 0.65);
+  padding: 10px 14px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.5);
+  color: var(--text-strong);
+}
+
+body.theme-dark .input-group select,
+body.theme-amoled .input-group select {
+  background: rgba(18, 22, 32, 0.8);
+  color: var(--text-strong);
+  border-color: rgba(120, 134, 200, 0.3);
+}
+
+.input-group.toggle {
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 4px;
+}
+
+.input-group.toggle input[type="checkbox"] {
+  width: 48px;
+  height: 24px;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  appearance: none;
+  position: relative;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.input-group.toggle input[type="checkbox"]::after {
+  content: "";
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #ffffff;
+  box-shadow: 0 1px 3px rgba(22, 26, 44, 0.3);
+  transition: transform 0.2s ease;
+}
+
+.input-group.toggle input[type="checkbox"]:checked {
+  background: var(--accent);
+}
+
+.input-group.toggle input[type="checkbox"]:checked::after {
+  transform: translateX(24px);
+}
+
+.session-meta {
+  display: grid;
+  gap: 10px;
+  margin: 0;
+}
+
+.session-meta div {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.session-meta dd {
+  margin: 0;
+  font-weight: 600;
+  color: var(--text-strong);
+}
+
+.panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.panel-help {
+  margin: 0 0 14px;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.memory-list {
+  list-style: decimal-leading-zero inside;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 12px;
+  max-height: 240px;
+  overflow: auto;
+}
+
+.memory-list li {
+  background: var(--surface-panel-strong);
+  border-radius: var(--radius-small);
+  padding: 12px 14px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25);
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  font-size: 0.85rem;
+}
+
+.memory-list li.empty {
+  opacity: 0.7;
+  font-style: italic;
+}
+
+.chat-pane {
+  background: var(--surface-panel);
+  border-radius: var(--radius-large);
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+}
+
+.chat-log {
+  flex: 1;
+  padding: clamp(20px, 2.8vw, 36px);
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  scroll-behavior: smooth;
+}
+
+.chat-message {
+  display: flex;
+  gap: 16px;
+  max-width: 100%;
+}
+
+.chat-message.user {
+  justify-content: flex-end;
+}
+
+.chat-avatar {
+  width: 44px;
+  height: 44px;
+  border-radius: 16px;
+  display: grid;
+  place-items: center;
+  font-size: 1.2rem;
+  background: rgba(255, 255, 255, 0.7);
+  color: var(--accent);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6), 0 8px 18px rgba(35, 45, 75, 0.18);
+}
+
+.chat-message.user .chat-avatar {
+  background: var(--surface-chat-user);
+  color: var(--text-inverse);
+}
+
+.chat-bubble {
+  max-width: min(640px, 82vw);
+  padding: 16px 18px;
+  border-radius: 22px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45), 0 18px 40px rgba(18, 25, 56, 0.18);
+  line-height: 1.6;
+  font-size: 0.97rem;
+}
+
+.chat-message.assistant .chat-bubble {
+  background: var(--surface-chat-assistant);
+  color: var(--text-strong);
+}
+
+.chat-message.user .chat-bubble {
+  background: var(--surface-chat-user);
+  color: var(--text-inverse);
+  border-bottom-right-radius: 8px;
+}
+
+.chat-message.assistant .chat-bubble {
+  border-bottom-left-radius: 8px;
+}
+
+.chat-meta {
+  margin-top: 10px;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.chat-bubble p {
+  margin: 0 0 12px;
+}
+
+.chat-bubble p:last-child {
+  margin-bottom: 0;
+}
+
+.chat-bubble ul,
+.chat-bubble ol {
+  padding-left: 20px;
+  margin: 0 0 12px;
+}
+
+.chat-bubble code {
+  font-family: "Fira Code", "SFMono-Regular", Consolas, monospace;
+  font-size: 0.9rem;
+  background: rgba(0, 0, 0, 0.08);
+  padding: 2px 6px;
+  border-radius: 6px;
+}
+
+.chat-bubble pre {
+  background: rgba(16, 22, 44, 0.85);
+  color: #f5f9ff;
+  border-radius: 14px;
+  padding: 16px;
+  overflow-x: auto;
+  margin: 12px 0;
+  font-size: 0.9rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08), 0 16px 42px rgba(12, 14, 30, 0.35);
+}
+
+.chat-bubble pre code {
+  background: transparent;
+  padding: 0;
+  color: inherit;
+}
+
+.chat-bubble img {
+  max-width: 100%;
+  border-radius: 18px;
+  margin: 12px 0;
+  box-shadow: 0 18px 38px rgba(20, 24, 40, 0.22);
+  border: 1px solid rgba(255, 255, 255, 0.35);
+}
+
+.composer {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px clamp(20px, 3vw, 32px) 20px;
+  border-top: 1px solid rgba(255, 255, 255, 0.28);
+  background: rgba(255, 255, 255, 0.6);
+  border-bottom-left-radius: var(--radius-large);
+  border-bottom-right-radius: var(--radius-large);
+}
+
+body.theme-dark .composer,
+body.theme-amoled .composer {
+  background: rgba(12, 16, 28, 0.82);
+}
+
+.composer textarea {
+  resize: none;
+  min-height: 64px;
+  border-radius: var(--radius-medium);
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  padding: 14px 16px;
+  background: rgba(255, 255, 255, 0.7);
+  color: var(--text-strong);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.5);
+}
+
+body.theme-dark .composer textarea,
+body.theme-amoled .composer textarea {
+  background: rgba(18, 22, 32, 0.84);
+  border-color: rgba(120, 134, 200, 0.3);
+  color: var(--text-strong);
+}
+
+.composer textarea:focus {
+  outline: 2px solid rgba(82, 116, 255, 0.6);
+  outline-offset: 2px;
+}
+
+.composer-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.composer-actions {
+  display: flex;
+  gap: 10px;
+}
+
+.primary-button {
+  border: none;
+  border-radius: 999px;
+  padding: 10px 24px;
+  font-weight: 600;
+  background: linear-gradient(135deg, #5f80ff, #4a8dff);
+  color: #fff;
+  box-shadow: 0 10px 25px rgba(82, 116, 255, 0.35);
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.primary-button:disabled {
+  opacity: 0.6;
+  cursor: progress;
+  box-shadow: none;
+}
+
+.primary-button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 30px rgba(82, 116, 255, 0.4);
+}
+
+.ghost-button {
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-strong);
+  padding: 8px 16px;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.ghost-button:hover {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.toast {
+  position: fixed;
+  right: 32px;
+  bottom: 32px;
+  min-width: 260px;
+  max-width: min(360px, 90vw);
+  padding: 14px 18px;
+  border-radius: 16px;
+  background: rgba(24, 28, 52, 0.88);
+  color: #f4f6ff;
+  box-shadow: 0 18px 42px rgba(12, 16, 32, 0.45);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  font-size: 0.95rem;
+  backdrop-filter: blur(18px);
+}
+
+.toast.success {
+  background: rgba(40, 160, 120, 0.88);
+}
+
+.toast.error {
+  background: rgba(210, 72, 105, 0.88);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 1100px) {
+  .window-body {
+    grid-template-columns: 1fr;
+  }
+
+  .control-pane {
+    order: 2;
+  }
+}
+
+@media (max-width: 768px) {
+  body {
+    overflow-y: auto;
+  }
+
+  .desktop-shell {
+    padding: 18px;
+  }
+
+  .taskbar {
+    margin-bottom: 16px;
+  }
+
+  .window-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 16px;
+  }
+
+  .window-body {
+    padding: 18px;
+  }
+
+  .chat-bubble {
+    max-width: 100%;
+  }
+
+  .chat-log {
+    padding: 18px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Summary
- add a Windows 11 2025 style landing page with configuration controls, chat log, and toast UI for the Pollinations assistant
- script the client to fetch ai-instruct, manage memories/code/image parsing, and call the Pollinations OpenAI endpoint with recent history
- introduce shared styling, Node validation/build scripts, and a Pages workflow that enforces the POLLINATIONS_TOKEN secret during CI

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68c980d12c1c8329b4cde546010b7419